### PR TITLE
[FIX]: userPrincipal null인 경우 조회 가능 수정

### DIFF
--- a/src/main/java/com/finfellows/domain/educontent/dto/response/EduContentResponse.java
+++ b/src/main/java/com/finfellows/domain/educontent/dto/response/EduContentResponse.java
@@ -16,5 +16,9 @@ public class EduContentResponse {
     private LocalDateTime created_at;
     private String title;
     private String content;
-    private boolean bookmarked;
+    private Boolean bookmarked;
+
+    public void setBookmarked(Object bookmarked) {
+        this.bookmarked = (Boolean) bookmarked;
+    }
 }

--- a/src/main/java/com/finfellows/domain/educontent/presentation/EduContentController.java
+++ b/src/main/java/com/finfellows/domain/educontent/presentation/EduContentController.java
@@ -44,7 +44,18 @@ public class EduContentController {
     })
     @GetMapping
     public ResponseEntity<Page<EduContentResponse>> getAllEduContents(@CurrentUser UserPrincipal userPrincipal, Pageable pageable) {
-        Page<EduContentResponse> responsePage = eduContentService.getAllEduContents(userPrincipal.getId(), pageable);
+        Page<EduContentResponse> responsePage;
+
+        if (userPrincipal != null) {
+            responsePage = eduContentService.getAllEduContents(userPrincipal.getId(), pageable);
+        } else {
+            responsePage = eduContentService.getAllEduContents(null, pageable);
+        }
+
+        // userPrincipal이 null이면 bookmarked를 null로 설정
+        if (userPrincipal == null) {
+            responsePage.getContent().forEach(eduContentResponse -> eduContentResponse.setBookmarked(null));
+        }
         return new ResponseEntity<>(responsePage, HttpStatus.OK);
     }
 

--- a/src/main/java/com/finfellows/domain/newscontent/dto/response/NewsContentResponse.java
+++ b/src/main/java/com/finfellows/domain/newscontent/dto/response/NewsContentResponse.java
@@ -13,5 +13,9 @@ public class NewsContentResponse {
     private Long id;
     private String title;
     private String content;
-    private boolean bookmarked;
+    private Boolean bookmarked;
+
+    public void setBookmarked(Object bookmarked) {
+        this.bookmarked = (Boolean) bookmarked;
+    }
 }

--- a/src/main/java/com/finfellows/domain/newscontent/presentation/NewsContentController.java
+++ b/src/main/java/com/finfellows/domain/newscontent/presentation/NewsContentController.java
@@ -44,7 +44,17 @@ public class NewsContentController {
     })
     @GetMapping
     public ResponseEntity<Page<NewsContentResponse>> getAllNewsContents(@CurrentUser UserPrincipal userPrincipal, Pageable pageable) {
-        Page<NewsContentResponse> responsePage = newsContentService.getAllNewsContents(userPrincipal.getId(), pageable);
+        Page<NewsContentResponse> responsePage;
+
+        if (userPrincipal != null) {
+            responsePage = newsContentService.getAllNewsContents(userPrincipal.getId(), pageable);
+        } else {
+            responsePage = newsContentService.getAllNewsContents(null, pageable);
+        }
+        // userPrincipal이 null이면 bookmarked를 null로 설정
+        if (userPrincipal == null) {
+            responsePage.getContent().forEach(newsContentResponse -> newsContentResponse.setBookmarked(null));
+        }
         return new ResponseEntity<>(responsePage, HttpStatus.OK);
     }
 


### PR DESCRIPTION
비로그인 시, EduContent, NewsContent 조회 response Bookmark값 null로 고정

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}