### PR TITLE
[FIX] 금융상품 조회 시 중복 데이터 제거, 이율 타입 별 정렬 기준 기능 추가 (#131)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 
 	//query dsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'com.querydsl:querydsl-sql:5.0.0'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/com/finfellows/domain/product/domain/repository/FinancialProductOptionOrderByDefault.java
+++ b/src/main/java/com/finfellows/domain/product/domain/repository/FinancialProductOptionOrderByDefault.java
@@ -1,0 +1,47 @@
+package com.finfellows.domain.product.domain.repository;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Subselect;
+import org.hibernate.annotations.Synchronize;
+
+@Entity
+@Subselect("SELECT sfp.id as financial_product_id, sfp.product_name, sfp.company_name, sfp.maximum_preferred_interest_rate, sfp.interest_rate " +
+        "FROM ( " +
+        "    SELECT " +
+        "        fp.id, " +
+        "        fp.product_name, " +
+        "        fp.company_name, " +
+        "        fpo.maximum_preferred_interest_rate, " +
+        "        fpo.interest_rate, " +
+        "        ROW_NUMBER() OVER(PARTITION BY fp.product_name ORDER BY fpo.interest_rate DESC, fpo.maximum_preferred_interest_rate DESC) as rownum " +
+        "    FROM financial_product_option fpo " +
+        "    LEFT JOIN financial_product fp ON fp.id = fpo.financial_product_id " +
+        ") sfp " +
+        "WHERE sfp.rownum = 1")
+@Immutable
+@Synchronize({"financial_product", "financial_product_option"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FinancialProductOptionOrderByDefault {
+
+    @Id
+    @Column(name = "financial_product_id")
+    private Long financialProductId;
+
+    @Column(name = "product_name")
+    private String productName;
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "maximum_preferred_interest_rate")
+    private String maximumPreferredInterestRate;
+
+    @Column(name = "interest_rate")
+    private String interestRate;
+
+}

--- a/src/main/java/com/finfellows/domain/product/domain/repository/FinancialProductOptionOrderByMax.java
+++ b/src/main/java/com/finfellows/domain/product/domain/repository/FinancialProductOptionOrderByMax.java
@@ -1,0 +1,47 @@
+package com.finfellows.domain.product.domain.repository;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Subselect;
+import org.hibernate.annotations.Synchronize;
+
+@Entity
+@Subselect("SELECT sfp.id as financial_product_id, sfp.product_name, sfp.company_name, sfp.maximum_preferred_interest_rate, sfp.interest_rate " +
+        "FROM ( " +
+        "    SELECT " +
+        "        fp.id, " +
+        "        fp.product_name, " +
+        "        fp.company_name, " +
+        "        fpo.maximum_preferred_interest_rate, " +
+        "        fpo.interest_rate, " +
+        "        ROW_NUMBER() OVER(PARTITION BY fp.product_name ORDER BY fpo.maximum_preferred_interest_rate DESC, fpo.interest_rate DESC) as rownum " +
+        "    FROM financial_product_option fpo " +
+        "    LEFT JOIN financial_product fp ON fp.id = fpo.financial_product_id " +
+        ") sfp " +
+        "WHERE sfp.rownum = 1")
+@Immutable
+@Synchronize({"financial_product", "financial_product_option"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FinancialProductOptionOrderByMax {
+
+    @Id
+    @Column(name = "financial_product_id")
+    private Long financialProductId;
+
+    @Column(name = "product_name")
+    private String productName;
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "maximum_preferred_interest_rate")
+    private String maximumPreferredInterestRate;
+
+    @Column(name = "interest_rate")
+    private String interestRate;
+
+}

--- a/src/main/java/com/finfellows/domain/product/dto/condition/FinancialProductSearchCondition.java
+++ b/src/main/java/com/finfellows/domain/product/dto/condition/FinancialProductSearchCondition.java
@@ -18,4 +18,7 @@ public class FinancialProductSearchCondition {
     @Schema(type = "array", implementation = String.class, example = "[\"은행A\", \"은행B\"]", description = "은행 이름입니다.")
     private String[] bankNames;
 
+    @Schema(type = "string", example = "MAX, DEFAULT", description = "이율 정렬 기준입니다.")
+    private String interestRateType;
+
 }


### PR DESCRIPTION
* [FEAT] BankUpload API 구현

* [FIX]: 배열 쿼리 적용

* [FIX]: 이미지 URL 안나가는 현상 수정

* [FIX]: HomePage URL도 포함

* [FIX]: 이율타입 별 데이터 조회, 정렬 수정

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}